### PR TITLE
Fix MixingTable recipe type mismatch

### DIFF
--- a/src/main/java/moriz/orangesunshine/block/entity/MixingTableBlockEntity.java
+++ b/src/main/java/moriz/orangesunshine/block/entity/MixingTableBlockEntity.java
@@ -1,6 +1,7 @@
 package moriz.orangesunshine.block.entity;
 
 import moriz.orangesunshine.recipe.MixingTableRecipe;
+import moriz.orangesunshine.recipe.PSRecipes;
 import moriz.orangesunshine.screen.MixingTableScreenHandler;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.block.BlockState;
@@ -172,7 +173,7 @@ public class MixingTableBlockEntity extends BlockEntity implements ExtendedScree
             inv.setStack(i, this.getStack(i));
         }
 
-        return getWorld().getRecipeManager().getFirstMatch(MixingTableRecipe.Type.INSTANCE, inv, getWorld());
+        return getWorld().getRecipeManager().getFirstMatch(PSRecipes.MIXING_TABLE_TYPE, inv, getWorld());
     }
 
     private boolean canInsertItemIntoOutputSlot(Item item) {

--- a/src/main/java/moriz/orangesunshine/recipe/MixingTableRecipe.java
+++ b/src/main/java/moriz/orangesunshine/recipe/MixingTableRecipe.java
@@ -64,11 +64,7 @@ public class MixingTableRecipe implements Recipe<SimpleInventory> {
 
     @Override
     public RecipeType<?> getType() {
-        return Type.INSTANCE;
-    }
-
-    public static class Type implements RecipeType<MixingTableRecipe> {
-        public static final Type INSTANCE = new Type();
+        return PSRecipes.MIXING_TABLE_TYPE;
     }
 
     public static class Serializer implements RecipeSerializer<MixingTableRecipe> {

--- a/src/main/java/moriz/orangesunshine/recipe/PSRecipes.java
+++ b/src/main/java/moriz/orangesunshine/recipe/PSRecipes.java
@@ -27,8 +27,8 @@ public interface PSRecipes {
     RecipeType<MortarPestleRecipe> MORTAR_PESTLE_TYPE = RecipeType.register("orangesunshine:mortar_pestle_recipe");
     RecipeSerializer<MortarPestleRecipe> MORTAR_PESTLE = RecipeSerializer.register("orangesunshine:mortar_pestle_recipe", new MortarPestleRecipe.Serializer());
 
-    RecipeType<MortarPestleRecipe> MIXING_TABLE_TYPE = RecipeType.register("orangesunshine:mixing");
-    RecipeSerializer<MortarPestleRecipe> MIXING_TABLE = RecipeSerializer.register("orangesunshine:mixing", new MortarPestleRecipe.Serializer());
+    RecipeType<MixingTableRecipe> MIXING_TABLE_TYPE = RecipeType.register("orangesunshine:mixing");
+    RecipeSerializer<MixingTableRecipe> MIXING_TABLE = RecipeSerializer.register("orangesunshine:mixing", new MixingTableRecipe.Serializer());
 
     static void bootstrap() {
         LootTableEvents.MODIFY.register((res, manager, id, supplier, setter) -> {


### PR DESCRIPTION
## Summary
- Fixed PSRecipes declaring MIXING_TABLE_TYPE and MIXING_TABLE with `MortarPestleRecipe` types instead of `MixingTableRecipe`, causing all MixingTable recipe lookups to fail
- Changed `MixingTableRecipe.getType()` and `MixingTableBlockEntity.getCurrentRecipe()` to use registered `PSRecipes.MIXING_TABLE_TYPE` instead of local `Type.INSTANCE` singleton
- Removed unused inner `Type` class from `MixingTableRecipe`

## Test plan
- [ ] Place items in a Mixing Table and verify recipes are found and crafting proceeds
- [ ] Verify Mixing Table output slot receives the correct crafted item
- [ ] Verify Mortar & Pestle recipes still work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)